### PR TITLE
Feat(Visual-Block): Introduce Visual-Block support with minor changes

### DIFF
--- a/lua/visual-surround/init.lua
+++ b/lua/visual-surround/init.lua
@@ -4,39 +4,18 @@ local Util = require("visual-surround.util")
 local Surround = {}
 
 ---@param char string
----@return string
-function Surround._get_opening_char(char)
+---@return string, string
+function Surround._get_char(char)
     if char == "(" or char == ")" then
-        return "("
+        return "(", ")"
+    elseif char == "[" or char == "]" then
+        return "[", "]"
+    elseif char == "{" or char == "}" then
+        return "{", "}"
+    elseif char == "<" or char == ">" then
+        return "<", ">"
     end
-    if char == "[" or char == "]" then
-        return "["
-    end
-    if char == "{" or char == "}" then
-        return "{"
-    end
-    if char == "<" or char == ">" then
-        return "<"
-    end
-    return char
-end
-
----@param char string
----@return string
-function Surround._get_closing_char(char)
-    if char == "(" or char == ")" then
-        return ")"
-    end
-    if char == "[" or char == "]" then
-        return "]"
-    end
-    if char == "{" or char == "}" then
-        return "}"
-    end
-    if char == "<" or char == ">" then
-        return ">"
-    end
-    return char
+    return char, char
 end
 
 function Surround._set_keymaps()
@@ -50,29 +29,59 @@ end
 
 ---@param char string
 function Surround.surround(char)
-    local opening_char = Surround._get_opening_char(char)
-    local closing_char = Surround._get_closing_char(char)
-    local bounds = Util.get_bounds()
-    local lines = vim.api.nvim_buf_get_text(
-        0,
-        bounds.vline_start - 1,
-        bounds.vcol_start - 1,
-        bounds.vline_end - 1,
-        bounds.vcol_end,
-        {}
-    )
-    lines[1] = string.rep(" ", Util.num_of_leading_whitespaces(lines[1]), "")
-        .. opening_char
-        .. Util.trim(lines[1])
-    lines[#lines] = lines[#lines] .. closing_char
-    vim.api.nvim_buf_set_text(
-        0,
-        bounds.vline_start - 1,
-        bounds.vcol_start - 1,
-        bounds.vline_end - 1,
-        bounds.vcol_end,
-        lines
-    )
+    local opening_char, closing_char = Surround._get_char(char)
+    local mode = vim.api.nvim_get_mode().mode
+    local bounds = Util.get_bounds(mode)
+    if mode == "v" or mode == "V" then
+        local lines = vim.api.nvim_buf_get_text(
+            0,
+            bounds.vline_start - 1,
+            bounds.vcol_start - 1,
+            bounds.vline_end - 1,
+            bounds.vcol_end,
+            {}
+        )
+        lines[1] = string.rep(" ", Util.num_of_leading_whitespaces(lines[1]), "")
+            .. opening_char
+            .. Util.trim(lines[1])
+        lines[#lines] = lines[#lines] .. closing_char
+        vim.api.nvim_buf_set_text(
+            0,
+            bounds.vline_start - 1,
+            bounds.vcol_start - 1,
+            bounds.vline_end - 1,
+            bounds.vcol_end,
+            lines
+        )
+    else
+        local lines = vim.api.nvim_buf_get_lines(0, bounds.vline_start - 1, bounds.vline_end, true)
+        -- Make sure we're normalized if in V-Block mode.
+        if bounds.vcol_end < bounds.vcol_start then
+            bounds.vcol_start, bounds.vcol_end = bounds.vcol_end, bounds.vcol_start
+        end
+        print(bounds.vline_start, bounds.vline_end, bounds.vcol_start, bounds.vcol_end)
+        for n = 1, #lines do
+            local line_mid = string.sub(lines[n], bounds.vcol_start, bounds.vcol_end)
+            local trimmed_line = Util.trim(line_mid)
+            print("trimmed_line:", trimmed_line)
+            if trimmed_line == "" then
+                -- Do nothing, skip iteration, continue, goto next, etc.
+            else
+                print("pre:", line_mid)
+                line_mid = string.rep(" ", Util.num_of_leading_whitespaces(line_mid), "")
+                    .. opening_char
+                    .. trimmed_line
+                line_mid = line_mid .. closing_char
+                print("post:", line_mid)
+
+                -- line = start mid end
+                lines[n] = string.sub(lines[n], 1, bounds.vcol_start - 1)
+                    .. line_mid
+                    .. string.sub(lines[n], bounds.vcol_end + 1, #lines[n])
+            end
+        end
+        vim.api.nvim_buf_set_lines(0, bounds.vline_start - 1, bounds.vline_end, true, lines)
+    end
     if Config.opts.exit_visual_mode then
         vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "x", true)
     end

--- a/lua/visual-surround/init.lua
+++ b/lua/visual-surround/init.lua
@@ -62,9 +62,7 @@ function Surround.surround(char)
         for n = 1, #lines do
             local line_mid = string.sub(lines[n], bounds.vcol_start, bounds.vcol_end)
             local trimmed_line = Util.trim(line_mid)
-            if trimmed_line == "" then
-                -- Do nothing, skip iteration, continue, goto next, etc.
-            else
+            if trimmed_line ~= "" then
                 line_mid = string.rep(" ", Util.num_of_leading_whitespaces(line_mid), "")
                     .. opening_char
                     .. trimmed_line

--- a/lua/visual-surround/init.lua
+++ b/lua/visual-surround/init.lua
@@ -59,20 +59,16 @@ function Surround.surround(char)
         if bounds.vcol_end < bounds.vcol_start then
             bounds.vcol_start, bounds.vcol_end = bounds.vcol_end, bounds.vcol_start
         end
-        print(bounds.vline_start, bounds.vline_end, bounds.vcol_start, bounds.vcol_end)
         for n = 1, #lines do
             local line_mid = string.sub(lines[n], bounds.vcol_start, bounds.vcol_end)
             local trimmed_line = Util.trim(line_mid)
-            print("trimmed_line:", trimmed_line)
             if trimmed_line == "" then
                 -- Do nothing, skip iteration, continue, goto next, etc.
             else
-                print("pre:", line_mid)
                 line_mid = string.rep(" ", Util.num_of_leading_whitespaces(line_mid), "")
                     .. opening_char
                     .. trimmed_line
                 line_mid = line_mid .. closing_char
-                print("post:", line_mid)
 
                 -- line = start mid end
                 lines[n] = string.sub(lines[n], 1, bounds.vcol_start - 1)

--- a/lua/visual-surround/util.lua
+++ b/lua/visual-surround/util.lua
@@ -13,19 +13,17 @@ function Util.info(msg)
     vim.notify("\n" .. msg, vim.log.levels.INFO, { title = "Speedtyper" })
 end
 
+---@param mode string
 ---@return { vline_start: integer, vcol_start: integer, vline_end: integer, vcol_end: integer }
-function Util.get_bounds()
+function Util.get_bounds(mode)
     local vline_start = vim.fn.line("v")
     local vcol_start = vim.fn.col("v")
     local vline_end = vim.fn.line(".")
     local vcol_end = vim.fn.col(".")
-    local mode = vim.api.nvim_get_mode().mode
 
     if mode == "V" then
         vcol_start = 1
         vcol_end = vim.fn.col("$") - 1
-    elseif mode ~= "v" then
-        error("Only visual and visual line modes are supported.")
     end
 
     if vline_start > vline_end then


### PR DESCRIPTION
Improvement: Move _get_opening_char and _get_closing_char to _get_char function, returning both opening and closing char.

Feat: Introduce Visual-Block mode support. Visual and Visual-Line modes work as previous. Visual-Block mode will inject opening and closing char for the entirety of the visual block per line. This is essentially an automatic version of doing visual-block in front of a section and after a section to inject opening and closing char as a macro.

Future implementation can merge both approaches probably, but right now this is working.

Note: I added ignoring empty lines on Visual Block mode, which is different behavior to Visual and Visual Line modes.